### PR TITLE
Add option to set custom texts variable name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,155 +1,157 @@
 var fs = require('fs');
 
-function getLangFromHeaders (req) {
-  var languagesRaw = req.headers['accept-language'] || 'NONE';
-  var lparts = languagesRaw.split(',');
-  var languages = [];
+function getLangFromHeaders(req) {
+    var languagesRaw = req.headers['accept-language'] || 'NONE';
+    var lparts = languagesRaw.split(',');
+    var languages = [];
 
-  for (var x = 0; x < lparts.length; x++) {
-    var unLangParts = lparts[x].split(';');
-    languages.push(unLangParts[0]);
-  }
+    for (var x = 0; x < lparts.length; x++) {
+        var unLangParts = lparts[x].split(';');
+        languages.push(unLangParts[0]);
+    }
 
-  return languages;
+    return languages;
 }
 
-function getLangFromCookie (req, cookieName) {
-  if (cookieName && req.session && req.session[cookieName]) {
-    return req.session[cookieName];
-  } else {
-    if (cookieName in req.cookies) {
-      return req.cookies[cookieName].toString();
+function getLangFromCookie(req, cookieName) {
+    if (cookieName && req.session && req.session[cookieName]) {
+        return req.session[cookieName];
     } else {
-      return '';
+        if (cookieName in req.cookies) {
+            return req.cookies[cookieName].toString();
+        } else {
+            return '';
+        }
     }
-  }
 }
 
-function loadLangJSONFiles (langPath, defaultLang) {
-  var i18n = [];
-  i18n[defaultLang] = [];
+function loadLangJSONFiles(langPath, defaultLang) {
+    var i18n = [];
+    i18n[defaultLang] = [];
 
-  var files = fs.readdirSync(langPath);
+    var files = fs.readdirSync(langPath);
 
-  if (files) {
-    for (var i = 0; i < files.length; i++) {
-      if (files[i].split('.').pop() === 'json' && files[i].substr(0, 1) !== '.') {
-        if (files[i].split('.').shift()) {
-          try {
-            delete require.cache[require.resolve(langPath + '/' + files[i])];
-          } catch (e) {}
+    if (files) {
+        for (var i = 0; i < files.length; i++) {
+            if (files[i].split('.').pop() === 'json' && files[i].substr(0, 1) !== '.') {
+                if (files[i].split('.').shift()) {
+                    try {
+                        delete require.cache[require.resolve(langPath + '/' + files[i])];
+                    } catch (e) {}
 
-          i18n[files[i].split('.').shift().toLowerCase()] = require(langPath + '/' + files[i]);
+                    i18n[files[i].split('.').shift().toLowerCase()] = require(langPath + '/' + files[i]);
+                }
+            }
         }
-      }
-    }
-  } else {
-    console.log('[i18n] No files in ' + langPath);
-  }
-  return i18n;
-}
-
-exports = module.exports = function (opts) {
-  var i18nTranslations = [];
-  var translationsPath = opts.translationsPath || 'i18n';
-  var cookieLangName = opts.cookieLangName || 'ulang';
-  var browserEnable = opts.browserEnable !== false;
-  var defaultLang = opts.defaultLang || 'en';
-  var paramLangName = opts.paramLangName || 'clang';
-  var siteLangs = opts.siteLangs || ['en'];
-  var textsVarName = opts.textsVarName || 'texts';
-
-  if (siteLangs.constructor !== Array) {
-    throw new Error('siteLangs must be an Array with supported langs.');
-  }
-
-  var computedLang = '';
-
-  i18nTranslations = loadLangJSONFiles(translationsPath, defaultLang);
-
-  fs.watch(translationsPath, function (event, filename) {
-    if (filename) {
-      try {
-        i18nTranslations = loadLangJSONFiles(translationsPath, defaultLang);
-      } catch (ee) {
-        // Some editors first empty the file and then save the content. This generate a "Unexpected end of input" error
-      }
-    }
-  });
-
-  return function i18n (req, res, next) {
-    var alreadyTryCookie = false;
-    var alreadyBrowser = false;
-
-    while (1) {
-      if (cookieLangName && alreadyTryCookie === false) {
-        var cLang = getLangFromCookie(req, cookieLangName);
-        if (cLang) {
-          computedLang = cLang;
-          break;
-        } else {
-          alreadyTryCookie = true;
-          continue;
-        }
-      } else if (browserEnable && alreadyBrowser === false) {
-        var wLang = getLangFromHeaders(req);
-
-        if (wLang.length) {
-          computedLang = wLang[0];
-          break;
-        } else {
-          alreadyBrowser = true;
-          continue;
-        }
-      } else {
-        computedLang = defaultLang;
-      }
-      if (computedLang !== '') {
-        break;
-      }
-    }
-
-    // User is setting a lang via get param. Store and use it.
-    if (paramLangName in req.query) {
-      if (siteLangs.indexOf(req.query[paramLangName]) > -1) {
-        if (cookieLangName && req.session) {
-          req.session[cookieLangName] = req.query[paramLangName].toString();
-        }
-        computedLang = req.query[paramLangName].toString();
-      }
-    }
-
-    function setDefaulti18n () {
-      req.app.locals[textsVarName] = i18nTranslations[defaultLang];
-      req.app.locals.lang = defaultLang;
-    }
-
-    computedLang = computedLang.toLowerCase();
-
-    // setting translations to views
-
-    if (computedLang in i18nTranslations) {
-      req.app.locals[textsVarName] = i18nTranslations[computedLang];
-      req.app.locals.lang = computedLang;
     } else {
-      if (computedLang.indexOf('-') > -1) {
-        // try extract "en" from "en-US"
-        var soloLang = computedLang.split('-')[0];
-        if (soloLang in i18nTranslations) {
-          req.app.locals[textsVarName] = i18nTranslations[soloLang];
-          req.app.locals.lang = soloLang;
-        } else {
-          setDefaulti18n();
-        }
-      } else {
-        setDefaulti18n();
-      }
+        console.log('[i18n] No files in ' + langPath);
+    }
+    return i18n;
+}
+
+exports = module.exports = function(opts) {
+    var i18nTranslations = [];
+    var translationsPath = opts.translationsPath || 'i18n';
+    var cookieLangName = opts.cookieLangName || 'ulang';
+    var browserEnable = opts.browserEnable !== false;
+    var defaultLang = opts.defaultLang || 'en';
+    var paramLangName = opts.paramLangName || 'clang';
+    var siteLangs = opts.siteLangs || ['en'];
+    var textsVarName = opts.textsVarName || 'texts';
+
+    if (siteLangs.constructor !== Array) {
+        throw new Error('siteLangs must be an Array with supported langs.');
     }
 
-    // req.i18n_all_texts=i18nTranslations;
-    req.i18n_texts = req.app.locals[textsVarName];
-    req.i18n_lang = req.app.locals.lang;
+    var computedLang = '';
 
-    next();
-  };
+    i18nTranslations = loadLangJSONFiles(translationsPath, defaultLang);
+
+    fs.watch(translationsPath, function(event, filename) {
+        if (filename) {
+            try {
+                i18nTranslations = loadLangJSONFiles(translationsPath, defaultLang);
+            } catch (ee) {
+                // Some editors first empty the file and then save the content. This generate a "Unexpected end of input" error
+            }
+        }
+    });
+
+    return function i18n(req, res, next) {
+        var alreadyTryCookie = false;
+        var alreadyBrowser = false;
+        // set textsVarName value for tests and variable recovery
+        req.app.locals.textsVarName = textsVarName;
+
+        while (1) {
+            if (cookieLangName && alreadyTryCookie === false) {
+                var cLang = getLangFromCookie(req, cookieLangName);
+                if (cLang) {
+                    computedLang = cLang;
+                    break;
+                } else {
+                    alreadyTryCookie = true;
+                    continue;
+                }
+            } else if (browserEnable && alreadyBrowser === false) {
+                var wLang = getLangFromHeaders(req);
+
+                if (wLang.length) {
+                    computedLang = wLang[0];
+                    break;
+                } else {
+                    alreadyBrowser = true;
+                    continue;
+                }
+            } else {
+                computedLang = defaultLang;
+            }
+            if (computedLang !== '') {
+                break;
+            }
+        }
+
+        // User is setting a lang via get param. Store and use it.
+        if (paramLangName in req.query) {
+            if (siteLangs.indexOf(req.query[paramLangName]) > -1) {
+                if (cookieLangName && req.session) {
+                    req.session[cookieLangName] = req.query[paramLangName].toString();
+                }
+                computedLang = req.query[paramLangName].toString();
+            }
+        }
+
+        function setDefaulti18n() {
+            req.app.locals[textsVarName] = i18nTranslations[defaultLang];
+            req.app.locals.lang = defaultLang;
+        }
+
+        computedLang = computedLang.toLowerCase();
+
+        // setting translations to views
+
+        if (computedLang in i18nTranslations) {
+            req.app.locals[textsVarName] = i18nTranslations[computedLang];
+            req.app.locals.lang = computedLang;
+        } else {
+            if (computedLang.indexOf('-') > -1) {
+                // try extract "en" from "en-US"
+                var soloLang = computedLang.split('-')[0];
+                if (soloLang in i18nTranslations) {
+                    req.app.locals[textsVarName] = i18nTranslations[soloLang];
+                    req.app.locals.lang = soloLang;
+                } else {
+                    setDefaulti18n();
+                }
+            } else {
+                setDefaulti18n();
+            }
+        }
+
+        // req.i18n_all_texts=i18nTranslations;
+        req.i18n_texts = req.app.locals[textsVarName];
+        req.i18n_lang = req.app.locals.lang;
+
+        next();
+    };
 };

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ exports = module.exports = function (opts) {
   var defaultLang = opts.defaultLang || 'en';
   var paramLangName = opts.paramLangName || 'clang';
   var siteLangs = opts.siteLangs || ['en'];
+  var textsVarName = opts.textsVarName || 'texts';
 
   if (siteLangs.constructor !== Array) {
     throw new Error('siteLangs must be an Array with supported langs.');
@@ -119,23 +120,23 @@ exports = module.exports = function (opts) {
     }
 
     function setDefaulti18n () {
-      req.app.locals.texts = i18nTranslations[defaultLang];
+      req.app.locals[textsVarName] = i18nTranslations[defaultLang];
       req.app.locals.lang = defaultLang;
     }
 
     computedLang = computedLang.toLowerCase();
 
-    // setting texts to views
+    // setting translations to views
 
     if (computedLang in i18nTranslations) {
-      req.app.locals.texts = i18nTranslations[computedLang];
+      req.app.locals[textsVarName] = i18nTranslations[computedLang];
       req.app.locals.lang = computedLang;
     } else {
       if (computedLang.indexOf('-') > -1) {
         // try extract "en" from "en-US"
         var soloLang = computedLang.split('-')[0];
         if (soloLang in i18nTranslations) {
-          req.app.locals.texts = i18nTranslations[soloLang];
+          req.app.locals[textsVarName] = i18nTranslations[soloLang];
           req.app.locals.lang = soloLang;
         } else {
           setDefaulti18n();
@@ -146,7 +147,7 @@ exports = module.exports = function (opts) {
     }
 
     // req.i18n_all_texts=i18nTranslations;
-    req.i18n_texts = req.app.locals.texts;
+    req.i18n_texts = req.app.locals[textsVarName];
     req.i18n_lang = req.app.locals.lang;
 
     next();

--- a/test/test.js
+++ b/test/test.js
@@ -5,153 +5,160 @@ var path = require('path');
 var i18nmod = require('..');
 var res = {};
 
-function getExpressReq (headerLang, session, query) {
-  headerLang = headerLang || {};
-  session = session || {};
-  query = query || {};
+function getExpressReq(headerLang, session, query) {
+    headerLang = headerLang || {};
+    session = session || {};
+    query = query || {};
 
-  return {
-    session: session,
-    cookies: {},
-    query: query,
-    headers: headerLang,
-    app: {locals: {}}
-  };
+    return {
+        session: session,
+        cookies: {},
+        query: query,
+        headers: headerLang,
+        app: { locals: {} }
+    };
 }
 
-describe('i18n-express', function () {
-  describe('middleware', function () {
-    it('should set default language', function (done) {
-      var req = getExpressReq();
+describe('i18n-express', function() {
+    describe('middleware', function() {
+        it('should set \'texts\' to a desired variable', function(done) {
+            var req = getExpressReq();
 
-      var mws = i18nmod({
-        translationsPath: path.join(__dirname, 'translations'),
-        siteLangs: ['en', 'es']
-      });
+            var mws = i18nmod({
+                translationsPath: path.join(__dirname, 'translations'),
+                siteLangs: ['en', 'es'],
+                textsVarName: 'testVar'
+            });
 
-      mws(req, res, function () {
-        assert.equal('en', req.app.locals.lang);
-        assert.equal('English', req.app.locals.texts.TRANSLATION);
-        done();
-      });
+            mws(req, res, function() {
+                assert.equal('testVar', req.app.locals.textsVarName);
+                done();
+            });
+        });
+
+        it('should set default language', function(done) {
+            var req = getExpressReq();
+
+            var mws = i18nmod({
+                translationsPath: path.join(__dirname, 'translations'),
+                siteLangs: ['en', 'es']
+            });
+
+            mws(req, res, function() {
+                assert.equal('en', req.app.locals.lang);
+                assert.equal('English', req.app.locals.texts.TRANSLATION);
+                done();
+            });
+        });
+
+        it('should set user defined default language', function(done) {
+            var req = getExpressReq();
+
+            var mws = i18nmod({
+                translationsPath: path.join(__dirname, 'translations'),
+                siteLangs: ['en', 'es'],
+                defaultLang: 'es'
+            });
+
+            mws(req, res, function() {
+                assert.equal('es', req.app.locals.lang);
+                assert.equal('Spanish', req.app.locals.texts.TRANSLATION);
+                done();
+            });
+        });
+
+        it('should use browser language', function(done) {
+            var req = getExpressReq({ 'accept-language': 'es-AR,en;q=0.8,pt;q=0.6' });
+
+            var mws = i18nmod({
+                translationsPath: path.join(__dirname, 'translations'),
+                siteLangs: ['en', 'es']
+            });
+
+            mws(req, res, function() {
+                assert.equal('es', req.app.locals.lang);
+                assert.equal('Spanish', req.app.locals.texts.TRANSLATION);
+                done();
+            });
+        });
+
+        it('shouldn\'t use browser language beacuase is disabled', function(done) {
+            var req = getExpressReq({ 'accept-language': 'es-AR,en;q=0.8,pt;q=0.6' });
+
+            var mws = i18nmod({
+                translationsPath: path.join(__dirname, 'translations'),
+                siteLangs: ['en', 'es'],
+                browserEnable: false
+            });
+
+            mws(req, res, function() {
+                assert.equal('en', req.app.locals.lang);
+                assert.equal('English', req.app.locals.texts.TRANSLATION);
+                done();
+            });
+        });
+
+        it('should use session/cookie stored language', function(done) {
+            var req = getExpressReq({ 'accept-language': 'es-AR,en;q=0.8,pt;q=0.6' }, { 'ulang': 'pt' });
+
+            var mws = i18nmod({
+                translationsPath: path.join(__dirname, 'translations'),
+                siteLangs: ['en', 'es', 'pt'],
+                browserEnable: false
+            });
+
+            mws(req, res, function() {
+                assert.equal('pt', req.app.locals.lang);
+                assert.equal('Portuges', req.app.locals.texts.TRANSLATION);
+                done();
+            });
+        });
+
+        it('should not use session/cookie stored language if translations doesn\'t exist', function(done) {
+            var req = getExpressReq({ 'accept-language': 'es-AR,en;q=0.8,pt;q=0.6' }, { 'ulang': 'it' });
+
+            var mws = i18nmod({
+                translationsPath: path.join(__dirname, 'translations'),
+                siteLangs: ['en', 'es', 'pt', 'it'],
+                browserEnable: false
+            });
+
+            mws(req, res, function() {
+                assert.equal('en', req.app.locals.lang);
+                assert.equal('English', req.app.locals.texts.TRANSLATION);
+                done();
+            });
+        });
+
+        it('should change language using get query and store the new value', function(done) {
+            var req = getExpressReq({ 'accept-language': 'es-AR,en;q=0.8,pt;q=0.6' }, {}, { 'clang': 'pt' });
+
+            var mws = i18nmod({
+                translationsPath: path.join(__dirname, 'translations'),
+                siteLangs: ['en', 'es', 'pt']
+            });
+
+            mws(req, res, function() {
+                assert.equal('pt', req.session.ulang);
+                assert.equal('pt', req.app.locals.lang);
+                assert.equal('Portuges', req.app.locals.texts.TRANSLATION);
+                done();
+            });
+        });
+
+        it('should use specific language by country', function(done) {
+            var req = getExpressReq({ 'accept-language': 'en-US,en;q=0.8,pt;q=0.6' });
+
+            var mws = i18nmod({
+                translationsPath: path.join(__dirname, 'translations'),
+                siteLangs: ['en', 'es', 'en-us']
+            });
+
+            mws(req, res, function() {
+                assert.equal('en-us', req.app.locals.lang);
+                assert.equal('English US', req.app.locals.texts.TRANSLATION);
+                done();
+            });
+        });
     });
-
-    it('should set user defined default language', function (done) {
-      var req = getExpressReq();
-
-      var mws = i18nmod({
-        translationsPath: path.join(__dirname, 'translations'),
-        siteLangs: ['en', 'es'],
-        defaultLang: 'es'
-      });
-
-      mws(req, res, function () {
-        assert.equal('es', req.app.locals.lang);
-        assert.equal('Spanish', req.app.locals.texts.TRANSLATION);
-        done();
-      });
-    });
-
-    it('should use browser language', function (done) {
-      var req = getExpressReq({'accept-language': 'es-AR,en;q=0.8,pt;q=0.6'});
-
-      var mws = i18nmod({
-        translationsPath: path.join(__dirname, 'translations'),
-        siteLangs: ['en', 'es']
-      });
-
-      mws(req, res, function () {
-        assert.equal('es', req.app.locals.lang);
-        assert.equal('Spanish', req.app.locals.texts.TRANSLATION);
-        done();
-      });
-    });
-
-    it('shouldn\'t use browser language beacuase is disabled', function (done) {
-      var req = getExpressReq({'accept-language': 'es-AR,en;q=0.8,pt;q=0.6'});
-
-      var mws = i18nmod({
-        translationsPath: path.join(__dirname, 'translations'),
-        siteLangs: ['en', 'es'],
-        browserEnable: false
-      });
-
-      mws(req, res, function () {
-        assert.equal('en', req.app.locals.lang);
-        assert.equal('English', req.app.locals.texts.TRANSLATION);
-        done();
-      });
-    });
-
-    it('should use session/cookie stored language', function (done) {
-      var req = getExpressReq(
-                {'accept-language': 'es-AR,en;q=0.8,pt;q=0.6'},
-                {'ulang': 'pt'}
-                );
-
-      var mws = i18nmod({
-        translationsPath: path.join(__dirname, 'translations'),
-        siteLangs: ['en', 'es', 'pt'],
-        browserEnable: false
-      });
-
-      mws(req, res, function () {
-        assert.equal('pt', req.app.locals.lang);
-        assert.equal('Portuges', req.app.locals.texts.TRANSLATION);
-        done();
-      });
-    });
-
-    it('should not use session/cookie stored language if translations doesn\'t exist', function (done) {
-      var req = getExpressReq(
-                {'accept-language': 'es-AR,en;q=0.8,pt;q=0.6'},
-                {'ulang': 'it'}
-                );
-
-      var mws = i18nmod({
-        translationsPath: path.join(__dirname, 'translations'),
-        siteLangs: ['en', 'es', 'pt', 'it'],
-        browserEnable: false
-      });
-
-      mws(req, res, function () {
-        assert.equal('en', req.app.locals.lang);
-        assert.equal('English', req.app.locals.texts.TRANSLATION);
-        done();
-      });
-    });
-
-    it('should change language using get query and store the new value', function (done) {
-      var req = getExpressReq({'accept-language': 'es-AR,en;q=0.8,pt;q=0.6'},
-                  {},
-                  {'clang': 'pt'});
-
-      var mws = i18nmod({
-        translationsPath: path.join(__dirname, 'translations'),
-        siteLangs: ['en', 'es', 'pt']
-      });
-
-      mws(req, res, function () {
-        assert.equal('pt', req.session.ulang);
-        assert.equal('pt', req.app.locals.lang);
-        assert.equal('Portuges', req.app.locals.texts.TRANSLATION);
-        done();
-      });
-    });
-
-    it('should use specific language by country', function (done) {
-      var req = getExpressReq({'accept-language': 'en-US,en;q=0.8,pt;q=0.6'});
-
-      var mws = i18nmod({
-        translationsPath: path.join(__dirname, 'translations'),
-        siteLangs: ['en', 'es', 'en-us']
-      });
-
-      mws(req, res, function () {
-        assert.equal('en-us', req.app.locals.lang);
-        assert.equal('English US', req.app.locals.texts.TRANSLATION);
-        done();
-      });
-    });
-  });
 });


### PR DESCRIPTION
If a User wants another variable name for the translations, it should be possible by providing a custom variable name.

option: textsVarName
default: 'texts'

modified: index.js -> patch, test/test.js -> added a test for this new option