### PR TITLE
forces defaultLang to lower case to prevent issues with capitalization

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ exports = module.exports = function (opts) {
   var cookieLangName = opts.cookieLangName || 'ulang';
   var browserEnable = opts.browserEnable !== false;
   var defaultLang = opts.defaultLang || 'en';
+  defaultLang = defaultLang.toLowerCase();
   var paramLangName = opts.paramLangName || 'clang';
   var siteLangs = opts.siteLangs || ['en'];
   var textsVarName = opts.textsVarName || 'texts';


### PR DESCRIPTION
The package could not handle when I used upper case letters in defaultLang (e.g. "en_US"). Looks like it is because the language is forced to lower case in some places but not the defaultLang.